### PR TITLE
Remove feat-2.0 branch dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,15 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-casper-engine-test-support = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }
-casper-execution-engine = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" , features = ["test-support"] }
-casper-types = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" , default_features = false, features = ["datasize", "json-schema"] }
-casper-storage = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }
+casper-engine-test-support = { git = "https://github.com/casper-network/casper-node.git" }
+casper-execution-engine = { git = "https://github.com/casper-network/casper-node.git", features = [
+  "test-support",
+] }
+casper-types = { git = "https://github.com/casper-network/casper-node.git", default_features = false, features = [
+  "datasize",
+  "json-schema",
+] }
+casper-storage = { git = "https://github.com/casper-network/casper-node.git" }
 lmdb = "0.8.0"
 
 fs_extra = "1.2.0"


### PR DESCRIPTION
Hi @deuszex, happy new year, hope you are doing well.

Would you consider for now updating this branch so that I can keep your origin and compile it in consuming cep-78 tests ?

Just removing feat-2.0 branch indication.

Thanks